### PR TITLE
Request Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,3 +318,24 @@ The APIs reside at `localhost:8080` when running.
 To run a test request,
 you can send a GET to the health check endpoint:
 `curl localhost:8080/api/v1/healthcheck`
+
+### Logging
+
+Logging in this project is intentionally restricted to a single structured log line per request.
+The log line will be either Info or Error Level and will have a variety of key/value pairs associated with it.
+The primary reason for doing things this way is to aid in debugging issues in production by pre-bucketing all info by request. This allows you to use line-oriented tools to quickly determine if there are commonalities between errors. 
+
+The line logging is performed by the middleware in pkg/server/httpserver/logger.go, in code you interacti with it with these methods from appcontext. 
+
+> //LogRequestField adds a zap.Field to the line logged at the end of the request
+> LogRequestField(ctx context.Context, field zap.Field)
+
+You can call this anytime you have a piece of information that you might like associated with this request. e.g.:
+* user_id
+* auth_type
+* number_of_dogs
+
+> // LogRequestError adds a message to the request log line and also sets it to log at the Error level
+> LogRequestError(ctx context.Context, message string, err error)
+
+You should call this at most once in a request if you want the request to log at the Error level. The message will be logged with an "error_message" key and the error will be logged with the zap standard "error" key. In general, these should generally correspond with requests that have 5xx status codes. Error log levels may trigger notificactions and require investigation. 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/lib/pq v1.0.0
+	github.com/lib/pq v1.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.10.0
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,7 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc h1:NCy3Ohtk6Iny5V/reW2Ktypo4zIpWBdRJ1uFMjBxdg8=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.7.0 h1:h93mCPfUSkaul3Ka/VG8uZdmW1uMHDGxzu0NWHuJmHY=
+github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -197,6 +199,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -272,6 +276,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -324,6 +330,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/pkg/apis/v1/http/handlers/dog_test.go
+++ b/pkg/apis/v1/http/handlers/dog_test.go
@@ -115,6 +115,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 		)
 		s.NoError(err)
 		req = mux.SetURLVars(req, map[string]string{"dog_id": dog.ID.String()})
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -160,6 +161,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			"/dog",
 			nil,
 		)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 		s.NoError(err)
 
 		DogHandler{
@@ -181,6 +183,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			bytes.NewBufferString("{x: nil}"),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -206,6 +209,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			bytes.NewBuffer(dogBytes),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -228,6 +232,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			bytes.NewBuffer(dogBytes),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -252,6 +257,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			nil,
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -272,6 +278,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			bytes.NewBufferString("{x: nil}"),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -297,6 +304,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			bytes.NewBuffer(dogBytes),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -317,6 +325,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 			bytes.NewBufferString(""),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 		req = mux.SetURLVars(req, map[string]string{"dog_id": dog.ID.String()})
 
 		DogHandler{

--- a/pkg/apis/v1/http/handlers/dogs_test.go
+++ b/pkg/apis/v1/http/handlers/dogs_test.go
@@ -36,6 +36,7 @@ func (s HandlerTestSuite) TestDogsHandler_Handle() {
 			bytes.NewBufferString(""),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogsHandler{
 			s.base,
@@ -62,6 +63,7 @@ func (s HandlerTestSuite) TestDogsHandler_Handle() {
 			bytes.NewBufferString(""),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogsHandler{
 			s.base,
@@ -80,6 +82,7 @@ func (s HandlerTestSuite) TestDogsHandler_Handle() {
 			bytes.NewBufferString(""),
 		)
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogsHandler{
 			s.base,

--- a/pkg/apis/v1/http/handlers/handler_base_test.go
+++ b/pkg/apis/v1/http/handlers/handler_base_test.go
@@ -33,7 +33,9 @@ func (w *failWriter) Header() http.Header {
 }
 
 func (s HandlerTestSuite) TestWriteErrorResponse() {
-	ctx, _ := appcontext.WithTrace(context.Background())
+	ctx := context.Background()
+	ctx, _ = appcontext.WithTrace(ctx)
+	ctx = appcontext.WithEmptyRequestLog(ctx)
 	traceID, ok := appcontext.Trace(ctx)
 	s.True(ok)
 

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -15,6 +15,7 @@ const (
 	loggerKey contextKey = iota
 	traceKey
 	userKey
+	requestLogKey
 )
 
 // WithLogger returns a context with the given logger
@@ -49,4 +50,46 @@ func WithUser(ctx context.Context, user models.User) context.Context {
 func User(ctx context.Context) (models.User, bool) {
 	user, ok := ctx.Value(userKey).(models.User)
 	return user, ok
+}
+
+// requestLog keeps track of all the info to be logged in the request log line
+type requestLog struct {
+	fields       []zap.Field
+	errorMessage string
+	error        bool
+}
+
+// LogRequestField adds a zap.Field to the line logged at the end of the request
+func LogRequestField(ctx context.Context, field zap.Field) {
+	requestLog, ok := ctx.Value(requestLogKey).(*requestLog)
+	if !ok {
+		panic("Configuration Error, make sure you call WithEmptyRequestLog before LogRequestField")
+	}
+
+	// TODO, figure out how to make this threadsafe
+	requestLog.fields = append(requestLog.fields, field)
+}
+
+// LogRequestError adds a message to the request log line and also sets it to log at the Error level
+func LogRequestError(ctx context.Context, message string, err error) {
+	requestLog, ok := ctx.Value(requestLogKey).(*requestLog)
+	if !ok {
+		panic("Configuration Error, make sure you call WithEmptyRequestLog before LogRequestField")
+	}
+
+	requestLog.fields = append(requestLog.fields, zap.Error(err))
+	requestLog.errorMessage = message
+	requestLog.error = true
+}
+
+// WithEmptyRequestLog returns a context with the request User
+func WithEmptyRequestLog(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestLogKey, &requestLog{})
+}
+
+// RequestLogFields returns all the fields added during the request
+func RequestLogFields(ctx context.Context) ([]zap.Field, bool) {
+	requestLog, ok := ctx.Value(requestLogKey).(*requestLog)
+
+	return requestLog.fields, ok
 }

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -93,3 +93,13 @@ func RequestLogFields(ctx context.Context) ([]zap.Field, bool) {
 
 	return requestLog.fields, ok
 }
+
+// RequestErrorInfo returns three variables:
+//     did_error bool: true if LogRequestError was called
+//     error_message string: the message logged with the call to LogRequestError
+//     ok bool: wether this data was sucessfully extracted from the context
+func RequestErrorInfo(ctx context.Context) (bool, string, bool) {
+	requestLog, ok := ctx.Value(requestLogKey).(*requestLog)
+
+	return requestLog.error, requestLog.errorMessage, ok
+}

--- a/pkg/server/httpserver/logger.go
+++ b/pkg/server/httpserver/logger.go
@@ -62,7 +62,17 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 
 		allfields := append(fields, requestFields...)
 
-		logger.Info("Request Complete", allfields...)
+		didError, errorMessage, ok := appcontext.RequestErrorInfo(ctx)
+		if !ok {
+			logger.Error("Error info not found on this request")
+		}
+
+		if didError {
+			allfields = append(allfields, zap.String("error_message", errorMessage))
+			logger.Error("Request Complete", allfields...)
+		} else {
+			logger.Info("Request Complete", allfields...)
+		}
 	})
 }
 

--- a/pkg/server/httpserver/logger.go
+++ b/pkg/server/httpserver/logger.go
@@ -10,6 +10,21 @@ import (
 
 const traceField string = "traceID"
 
+// In order to log the status we need to wrap the ResponseWriter
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func newStatusRecorder(w http.ResponseWriter) *statusRecorder {
+	return &statusRecorder{w, 200}
+}
+
+func (rec *statusRecorder) WriteHeader(code int) {
+	rec.status = code
+	rec.ResponseWriter.WriteHeader(code)
+}
+
 func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -20,6 +35,7 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 			logger.Error("Failed to get trace ID from context")
 		}
 		ctx = appcontext.WithLogger(ctx, logger)
+		ctx = appcontext.WithEmptyRequestLog(ctx)
 
 		fields := []zap.Field{
 			zap.String("accepted-language", r.Header.Get("accepted-language")),
@@ -32,9 +48,21 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 			zap.String("url", r.URL.String()),
 			zap.String("user-agent", r.UserAgent()),
 		}
-		logger.Info("Request", fields...)
 
-		next.ServeHTTP(w, r.WithContext(ctx))
+		rec := newStatusRecorder(w)
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		// get a couple more default fields
+		fields = append(fields, zap.Int("http_status", rec.status))
+
+		requestFields, ok := appcontext.RequestLogFields(ctx)
+		if !ok {
+			logger.Error("Fields not configured for this request")
+		}
+
+		allfields := append(fields, requestFields...)
+
+		logger.Info("Request Complete", allfields...)
 	})
 }
 

--- a/pkg/server/httpserver/logger_test.go
+++ b/pkg/server/httpserver/logger_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"bin/bork/pkg/appcontext"
 )
@@ -49,4 +51,40 @@ func (s ServerTestSuite) TestLoggerMiddleware() {
 
 		loggerMiddleware(testHandler).ServeHTTP(rr, req)
 	})
+
+	s.Run("do a single log field", func() {
+
+		req := httptest.NewRequest("GET", "/dogs/", nil)
+		rr := httptest.NewRecorder()
+		traceMiddleware := NewTraceMiddleware()
+
+		// let's get a logger we can inspect
+		logcore, recorded := observer.New(zapcore.InfoLevel)
+		testLogger := zap.New(logcore)
+
+		loggerMiddleware := NewLoggerMiddleware(testLogger)
+
+		// The handler will log a field and write a header
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			// let's add some log fields
+			appcontext.LogRequestField(r.Context(), zap.String("onekey", "onevalue"))
+
+			w.WriteHeader(404)
+		})
+
+		traceMiddleware(loggerMiddleware(testHandler)).ServeHTTP(rr, req)
+
+		// Check that we logged what we expected
+		s.Equal(1, recorded.Len())
+
+		line := recorded.All()[0]
+		s.Equal("Request Complete", line.Message)
+
+		s.Contains(line.Context, zap.String("host", "example.com"))
+		s.Contains(line.Context, zap.String("onekey", "onevalue"))
+		s.Contains(line.Context, zap.Int("http_status", 404))
+
+	})
+
 }

--- a/pkg/server/httpserver/logger_test.go
+++ b/pkg/server/httpserver/logger_test.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 
@@ -84,6 +85,44 @@ func (s ServerTestSuite) TestLoggerMiddleware() {
 		s.Contains(line.Context, zap.String("host", "example.com"))
 		s.Contains(line.Context, zap.String("onekey", "onevalue"))
 		s.Contains(line.Context, zap.Int("http_status", 404))
+
+	})
+
+	s.Run("log an error", func() {
+
+		req := httptest.NewRequest("GET", "/dogs/", nil)
+		rr := httptest.NewRecorder()
+		traceMiddleware := NewTraceMiddleware()
+
+		// let's get a logger we can inspect
+		logcore, recorded := observer.New(zapcore.InfoLevel)
+		testLogger := zap.New(logcore)
+
+		loggerMiddleware := NewLoggerMiddleware(testLogger)
+
+		// The handler will log a field and write a header
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			err := errors.New("this test is in error")
+
+			// let's add some log fields
+			appcontext.LogRequestError(r.Context(), "the test errored just like we planned", err)
+
+			w.WriteHeader(500)
+		})
+
+		traceMiddleware(loggerMiddleware(testHandler)).ServeHTTP(rr, req)
+
+		// Check that we logged what we expected
+		s.Equal(1, recorded.Len())
+
+		line := recorded.All()[0]
+		s.Equal("Request Complete", line.Message)
+		s.Equal(zap.ErrorLevel, line.Level)
+
+		s.Contains(line.Context, zap.String("host", "example.com"))
+		s.Contains(line.Context, zap.Int("http_status", 500))
+		s.Contains(line.Context, zap.String("error_message", "the test errored just like we planned"))
 
 	})
 


### PR DESCRIPTION
This PR changes the logging middleware to log a single log line per request. Docs are at the bottom of the README, reproduced here:

### Logging

Logging in this project is intentionally restricted to a single structured log line per request.
The log line will be either Info or Error Level and will have a variety of key/value pairs associated with it.
The primary reason for doing things this way is to aid in debugging issues in production by pre-bucketing all info by request. This allows you to use line-oriented tools to quickly determine if there are commonalities between errors. 

The line logging is performed by the middleware in pkg/server/httpserver/logger.go, in code you interacti with it with these methods from appcontext. 

> //LogRequestField adds a zap.Field to the line logged at the end of the request
> LogRequestField(ctx context.Context, field zap.Field)

You can call this anytime you have a piece of information that you might like associated with this request. e.g.:
* user_id
* auth_type
* number_of_dogs

> // LogRequestError adds a message to the request log line and also sets it to log at the Error level
> LogRequestError(ctx context.Context, message string, err error)

You should call this at most once in a request if you want the request to log at the Error level. The message will be logged with an "error_message" key and the error will be logged with the zap standard "error" key. In general, these should generally correspond with requests that have 5xx status codes. Error log levels may trigger notificactions and require investigation. 

--------------------------------

This is my first pass at this. I'm open to suggestion on how we should do this, especially how we should do errors. Here's an alternative I considered:

Zap has a convention where if you log a zap.Error field, the key is automatically set to "error" we could axe LogRequestError API and just inspect our list of fields for an "error" error and log at the Error level in that case. This way is more explict and includes an error_message. That way would shink things down but is a little bit more of a convention. Both cases right now require that you actually have an error in order to log at the error level which might be another things worth considering changing. I'm open to discussion. 