### PR TITLE
example of adapter pattern

### DIFF
--- a/pkg/server/httpserver/routes.go
+++ b/pkg/server/httpserver/routes.go
@@ -7,6 +7,7 @@ import (
 
 	"bin/bork/pkg/apis/v1/http/handlers"
 	"bin/bork/pkg/services"
+	"bin/bork/pkg/sources"
 	"bin/bork/pkg/sources/cache"
 	"bin/bork/pkg/sources/memory"
 	"bin/bork/pkg/sources/postgres"
@@ -75,7 +76,7 @@ func (s *Server) routes() {
 		handlerBase,
 		serviceFactory.NewFetchDogs(
 			services.NewAuthorizeFetchDogs(),
-			cache.NewStore(cacheConfig).FetchDogs,
+			sources.DogListerFunc(cache.NewStore(cacheConfig).FetchDogs),
 		),
 	)
 	api.Handle("/dogs", dogsHandler.Handle())

--- a/pkg/services/dogs.go
+++ b/pkg/services/dogs.go
@@ -10,6 +10,7 @@ import (
 	"bin/bork/pkg/appcontext"
 	"bin/bork/pkg/apperrors"
 	"bin/bork/pkg/models"
+	"bin/bork/pkg/sources"
 )
 
 // NewAuthorizeFetchDog authorizes fetching a dog
@@ -202,7 +203,7 @@ func NewAuthorizeFetchDogs() func(user models.User) (bool, error) {
 // NewFetchDogs returns a service function for fetching dogs
 func (f ServiceFactory) NewFetchDogs(
 	authorize func(user models.User) (bool, error),
-	fetch func(ctx context.Context) (*models.Dogs, error),
+	fetch sources.DogLister,
 ) func(ctx context.Context) (*models.Dogs, error) {
 	return func(ctx context.Context) (*models.Dogs, error) {
 		logger, ok := appcontext.Logger(ctx)
@@ -233,7 +234,7 @@ func (f ServiceFactory) NewFetchDogs(
 			}
 			return nil, &unauthorizedError
 		}
-		dogs, err := fetch(ctx)
+		dogs, err := fetch.ListDogs(ctx)
 		if err != nil {
 			queryError := apperrors.QueryError{
 				Err:       err,

--- a/pkg/services/dogs_test.go
+++ b/pkg/services/dogs_test.go
@@ -9,6 +9,7 @@ import (
 	"bin/bork/pkg/appcontext"
 	"bin/bork/pkg/apperrors"
 	"bin/bork/pkg/models"
+	"bin/bork/pkg/sources"
 )
 
 func (s ServicesTestSuite) NewDog() models.Dog {
@@ -460,7 +461,7 @@ func (s ServicesTestSuite) TestServiceFactory_NewFetchDogs() {
 	s.Run("returns dogs on golden path", func() {
 		fetchDogs := s.ServiceFactory.NewFetchDogs(
 			authorize,
-			fetch,
+			sources.DogListerFunc(fetch),
 		)
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
@@ -474,7 +475,7 @@ func (s ServicesTestSuite) TestServiceFactory_NewFetchDogs() {
 	s.Run("returns error with no user context", func() {
 		fetchDogs := s.ServiceFactory.NewFetchDogs(
 			authorize,
-			fetch,
+			sources.DogListerFunc(fetch),
 		)
 		ctx := context.Background()
 
@@ -490,7 +491,7 @@ func (s ServicesTestSuite) TestServiceFactory_NewFetchDogs() {
 		}
 		fetchDogs := s.ServiceFactory.NewFetchDogs(
 			noAuthorize,
-			fetch,
+			sources.DogListerFunc(fetch),
 		)
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
@@ -508,7 +509,7 @@ func (s ServicesTestSuite) TestServiceFactory_NewFetchDogs() {
 		}
 		fetchDogs := s.ServiceFactory.NewFetchDogs(
 			failAuthorize,
-			fetch,
+			sources.DogListerFunc(fetch),
 		)
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
@@ -521,12 +522,11 @@ func (s ServicesTestSuite) TestServiceFactory_NewFetchDogs() {
 
 	s.Run("returns error when fetch returns error", func() {
 		fetchErr := errors.New("failed to fetch")
-		failFetch := func(ctx context.Context) (*models.Dogs, error) {
-			return &models.Dogs{expectedDog}, fetchErr
-		}
 		fetchDogs := s.ServiceFactory.NewFetchDogs(
 			authorize,
-			failFetch,
+			sources.DogListerFunc(func(ctx context.Context) (*models.Dogs, error) {
+				return &models.Dogs{expectedDog}, fetchErr
+			}),
 		)
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})

--- a/pkg/sources/cache/dogs_test.go
+++ b/pkg/sources/cache/dogs_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 
 	"bin/bork/pkg/models"
+	"bin/bork/pkg/sources"
 )
 
 type fakeDogReadStore struct {
@@ -66,5 +67,10 @@ func (s StoreTestSuite) TestFetchDogs() {
 		s.NoError(err)
 		s.Equal(readStore.Dogs, *actualDogs)
 		s.True(s.store.dogStore.updatedAt.Equal(s.clock.Now()))
+	})
+
+	s.Run("ensure interface adapter signature", func() {
+		// This won't compile otherwise
+		var _ sources.DogLister = sources.DogListerFunc(readStore.FetchDogs)
 	})
 }

--- a/pkg/sources/interface.go
+++ b/pkg/sources/interface.go
@@ -1,0 +1,20 @@
+package sources
+
+import (
+	"bin/bork/pkg/models"
+	"context"
+)
+
+// DogLister fetches all the dogs in the system
+type DogLister interface {
+	ListDogs(context.Context) (*models.Dogs, error)
+}
+
+// DogListerFunc is an adapoter for any func with an appropriate signature
+// to satisfy the DogLister interface
+type DogListerFunc func(context.Context) (*models.Dogs, error)
+
+// ListDogs satisfies the DogLister.ListDogs interface function
+func (fn DogListerFunc) ListDogs(ctx context.Context) (*models.Dogs, error) {
+	return fn(ctx)
+}


### PR DESCRIPTION
as an example, this PR uses `/pkg/sources` to define the interface contract that multiple(?) implementation packages would implement against.