### PR TITLE
Example using docker-compose for local development and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:2020.01
+
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build test image
+          command: docker-compose -f docker-compose.test.yml build
+      - run:
+          name: Run tests
+          command: docker-compose -f docker-compose.test.yml run --rm bork_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.14.6-buster as base
+
+ENV GO111MODULE=auto
+WORKDIR /app
+
+FROM base as modules
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+FROM modules as build
+
+COPY cmd ./cmd
+COPY pkg ./pkg
+RUN go build -a -o bin/bork ./cmd/bork
+
+FROM modules as dev
+
+RUN go get golang.org/x/tools/gopls@latest
+RUN go get github.com/cosmtrek/air
+
+CMD ["./bin/bork"]
+
+FROM build as test
+
+CMD ["go", "test", "./pkg/..."]

--- a/Dockerfile.flyway
+++ b/Dockerfile.flyway
@@ -1,0 +1,4 @@
+FROM flyway/flyway:6.5
+
+COPY flyway.conf /flyway/conf/flyway.conf
+COPY migrations /flyway/migrations

--- a/README.md
+++ b/README.md
@@ -318,3 +318,19 @@ The APIs reside at `localhost:8080` when running.
 To run a test request,
 you can send a GET to the health check endpoint:
 `curl localhost:8080/api/v1/healthcheck`
+
+## Docker
+
+### Development
+
+This starts a docker container that mounts your local directory
+running air so that it will rebuild automatically as you change the code
+
+1. mkdir -p tmp
+1. docker-compose -f docker-compose.dev.yml up
+
+### Testing
+
+1. docker-compose -f docker-compose.test.yml down
+1. docker-compose -f docker-compose.test.yml run --rm bork_test
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,7 +40,9 @@ services:
       - /var/lib/postgresql/data
 
   flyway:
-    image: flyway/flyway:6.5
+    build:
+      context: .
+      dockerfile: Dockerfile.flyway
     depends_on:
       - db
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,56 @@
+version: '3.4'
+
+services:
+  bork_dev:
+    container_name: bork_dev
+    ports: [ "8080:8080" ]
+    build:
+      context: .
+      target: dev
+    volumes:
+      - ${GOPATH:-~/go}:/go:cached
+      - /private/var/folders:/var/folders:cached
+      - ${PWD}:${PWD}
+    working_dir: ${PWD}
+    environment:
+      APP_ENV: local
+      API_PROTOCOL: http
+      API_HOST: 0.0.0.0
+      API_PORT: 8080
+      PGUSER: postgres
+      PGPASS: postgres
+      PGHOST: db
+      PGDATABASE: bork_dev
+      PGPORT: 5432
+      PGSSLMODE: disable
+    # for the dev environment, run air to rebuild automatically
+    command: air
+    depends_on:
+      - db
+      - flyway
+  db:
+    ports: [ "5432:5432" ]
+    image: postgres:12.2
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: bork_dev
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  flyway:
+    image: flyway/flyway:6.5
+    depends_on:
+      - db
+    environment:
+      PGUSER: postgres
+      PGPASS: postgres
+      PGHOST: db
+      PGDATABSE: bork_dev
+      PGPORT: 5432
+      PGSSLMODE: disable
+    volumes:
+      - ./flyway.conf:/flyway/conf/flyway.conf
+      - ./migrations:/flyway/migrations
+    command: -connectRetries=60 migrate

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -33,7 +33,9 @@ services:
       - /var/lib/postgresql/data
 
   flyway:
-    image: flyway/flyway:6.5
+    build:
+      context: .
+      dockerfile: Dockerfile.flyway
     depends_on:
       - db_test
     environment:
@@ -43,7 +45,4 @@ services:
       PGDATABASE: bork_test
       PGPORT: 5432
       PGSSLMODE: disable
-    volumes:
-      - ./flyway.conf:/flyway/conf/flyway.conf
-      - ./migrations:/flyway/migrations
     command: -connectRetries=60 migrate

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,49 @@
+version: '3.4'
+
+services:
+  bork_test:
+    container_name: bork_test
+    build:
+      context: .
+      target: test
+    environment:
+      APP_ENV: test
+      API_PROTOCOL: http
+      API_HOST: 0.0.0.0
+      API_PORT: 8080
+      PGUSER: postgres
+      PGPASS: postgres
+      PGHOST: db_test
+      PGDATABASE: bork_test
+      PGPORT: 5432
+      PGSSLMODE: disable
+    depends_on:
+      - db_test
+      - flyway
+
+  db_test:
+    ports: [ "5432:5432" ]
+    image: postgres:12.2
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: bork_test
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  flyway:
+    image: flyway/flyway:6.5
+    depends_on:
+      - db_test
+    environment:
+      PGUSER: postgres
+      PGPASS: postgres
+      PGHOST: db_test
+      PGDATABASE: bork_test
+      PGPORT: 5432
+      PGSSLMODE: disable
+    volumes:
+      - ./flyway.conf:/flyway/conf/flyway.conf
+      - ./migrations:/flyway/migrations
+    command: -connectRetries=60 migrate


### PR DESCRIPTION
This is an almost certainly controversial approach, but I wanted to at least get the ideas out there.  I used a similar pattern at a previous place with great success.

The benefits as I see it:
1. Local development and testing work almost exactly the same way as CI
    1. There are some differences, but they are minor.  It greatly reduces the need to understand CircleCI specific things
1. Many projects can share a CircleCI config that is essentially the same with all of the logic being in the `docker-compose` files
1. Ties us less to CircleCI.  Any environment that can run docker can run our builds and tests.  When we have a client not using CircleCI, we can still use many of our same techniques.

The downsides:
1. CircleCI docker layer caching may not be as efficient/good as their workspace caching.  We might have slower builds or have to do funky things to speed things up
1. Parallelizing tests might be harder?  Not sure until we try it
1. docker is both good and bad.  This approach is probably only successful if we invest in it/ commit to it