### PR TITLE
trace id also as response header

### DIFF
--- a/pkg/apis/v1/http/handlers/handler_base_test.go
+++ b/pkg/apis/v1/http/handlers/handler_base_test.go
@@ -33,8 +33,7 @@ func (w *failWriter) Header() http.Header {
 }
 
 func (s HandlerTestSuite) TestWriteErrorResponse() {
-	ctx := context.Background()
-	ctx = appcontext.WithTrace(ctx)
+	ctx, _ := appcontext.WithTrace(context.Background())
 	traceID, ok := appcontext.Trace(ctx)
 	s.True(ok)
 

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -29,9 +29,9 @@ func Logger(ctx context.Context) (*zap.Logger, bool) {
 }
 
 // WithTrace returns a context with request trace
-func WithTrace(ctx context.Context) context.Context {
+func WithTrace(ctx context.Context) (context.Context, uuid.UUID) {
 	traceID := uuid.New()
-	return context.WithValue(ctx, traceKey, traceID)
+	return context.WithValue(ctx, traceKey, traceID), traceID
 }
 
 // Trace returns the context's trace UUID

--- a/pkg/appcontext/context_test.go
+++ b/pkg/appcontext/context_test.go
@@ -44,12 +44,11 @@ func (s ContextTestSuite) TestLogger() {
 }
 
 func (s ContextTestSuite) TestWithTrace() {
-	ctx := context.Background()
-
-	ctx = WithTrace(ctx)
+	ctx, tID := WithTrace(context.Background())
 	traceID := ctx.Value(traceKey).(uuid.UUID)
 
 	s.NotEqual(uuid.UUID{}, traceID)
+	s.Equal(tID.String(), traceID.String())
 }
 
 func (s ContextTestSuite) TestTrace() {

--- a/pkg/server/httpserver/trace.go
+++ b/pkg/server/httpserver/trace.go
@@ -6,10 +6,13 @@ import (
 	"bin/bork/pkg/appcontext"
 )
 
+const traceHeader = "X-TRACE-ID"
+
 func traceMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		next.ServeHTTP(w, r.WithContext(appcontext.WithTrace(ctx)))
+		ctx, traceID := appcontext.WithTrace(r.Context())
+		w.Header().Add(traceHeader, traceID.String())
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/pkg/server/httpserver/trace_test.go
+++ b/pkg/server/httpserver/trace_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func (s ServerTestSuite) TestTraceMiddleware() {
+	traceValue := ""
 	// this is the actual test, since the context is cancelled post request
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		traceID, ok := appcontext.Trace(r.Context())
-
+		traceValue = traceID.String()
 		s.True(ok)
 		s.NotEqual(uuid.UUID{}, traceID)
 	})
@@ -23,4 +24,7 @@ func (s ServerTestSuite) TestTraceMiddleware() {
 	middleware := NewTraceMiddleware()
 
 	middleware(testHandler).ServeHTTP(rr, req)
+
+	// Ensure what is in the header matches what is on the context
+	s.Equal(traceValue, rr.Header().Get(traceHeader))
 }


### PR DESCRIPTION
I have found that unique request identifiers, like the `traceID` in our sample app, are frequently useful not just on un-happy paths, but also frequently in happy paths as well. 

Adding the `traceID` as a response header makes it easy for a consumer to find the identifier.