### PR TITLE
separate read and write paths

### DIFF
--- a/pkg/apis/v1/http/handlers/dog_test.go
+++ b/pkg/apis/v1/http/handlers/dog_test.go
@@ -26,11 +26,11 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 	fakeFetchDog := func(ctx context.Context, id uuid.UUID) (*models.Dog, error) {
 		return &dog, nil
 	}
-	fakeCreateDog := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-		return dog, nil
+	fakeCreateDog := func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
+		return &dog.ID, nil
 	}
-	fakeUpdateDog := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-		return dog, nil
+	fakeUpdateDog := func(ctx context.Context, dog *models.Dog) error {
+		return nil
 	}
 
 	requestContext := context.Background()
@@ -193,7 +193,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 	})
 
 	s.Run("when create fails POST returns 500", func() {
-		failCreateDog := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
+		failCreateDog := func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
 			return nil, errors.New("failed to create dog")
 		}
 		rr := httptest.NewRecorder()
@@ -284,8 +284,8 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 	})
 
 	s.Run("when update fails PUT returns 500", func() {
-		failUpdateDog := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-			return nil, errors.New("failed to create dog")
+		failUpdateDog := func(ctx context.Context, dog *models.Dog) error {
+			return errors.New("failed to create dog")
 		}
 		rr := httptest.NewRecorder()
 		dogBytes, err := json.Marshal(dog)

--- a/pkg/services/dogs.go
+++ b/pkg/services/dogs.go
@@ -79,9 +79,9 @@ func NewAuthorizeCreateDog() func(user models.User, dog *models.Dog) (bool, erro
 // NewCreateDog returns a service function for creating a dog
 func (f ServiceFactory) NewCreateDog(
 	authorize func(user models.User, dog *models.Dog) (bool, error),
-	create func(ctx context.Context, dog *models.Dog) (*models.Dog, error),
-) func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-	return func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
+	create func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error),
+) func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
+	return func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
 		logger, ok := appcontext.Logger(ctx)
 		if !ok {
 			logger = f.logger
@@ -111,7 +111,7 @@ func (f ServiceFactory) NewCreateDog(
 			return nil, &unauthorizedError
 		}
 		dog.OwnerID = user.ID
-		createdDog, err := create(ctx, dog)
+		dogID, err := create(ctx, dog)
 		if err != nil {
 			queryError := apperrors.QueryError{
 				Err:       err,
@@ -120,7 +120,7 @@ func (f ServiceFactory) NewCreateDog(
 			}
 			return nil, &queryError
 		}
-		return createdDog, nil
+		return dogID, nil
 	}
 }
 
@@ -137,10 +137,10 @@ func NewAuthorizeUpdateDog() func(user models.User, dog *models.Dog) (bool, erro
 // NewUpdateDog returns a service function for updating a dog
 func (f ServiceFactory) NewUpdateDog(
 	authorize func(user models.User, dog *models.Dog) (bool, error),
-	update func(ctx context.Context, dog *models.Dog) (*models.Dog, error),
+	update func(ctx context.Context, dog *models.Dog) error,
 	fetch func(ctx context.Context, id uuid.UUID) (*models.Dog, error),
-) func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-	return func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
+) func(ctx context.Context, dog *models.Dog) error {
+	return func(ctx context.Context, dog *models.Dog) error {
 		logger, ok := appcontext.Logger(ctx)
 		if !ok {
 			logger = f.logger
@@ -153,7 +153,7 @@ func (f ServiceFactory) NewUpdateDog(
 				Resource:  apperrors.ContextResourceUser,
 				Operation: apperrors.ContextOperationGet,
 			}
-			return nil, &contextError
+			return &contextError
 		}
 		existingDog, err := fetch(ctx, dog.ID)
 		if err != nil {
@@ -162,12 +162,12 @@ func (f ServiceFactory) NewUpdateDog(
 				Resource:  models.Dog{},
 				Operation: apperrors.QueryUpdate,
 			}
-			return nil, &queryError
+			return &queryError
 		}
 		ok, err = authorize(user, existingDog)
 		if err != nil {
 			logger.Error("failed to authorize updateDog", zap.String("user", user.ID))
-			return nil, err
+			return err
 		}
 		if !ok {
 			unauthorizedError := apperrors.UnauthorizedError{
@@ -176,19 +176,18 @@ func (f ServiceFactory) NewUpdateDog(
 				Resource:  dog,
 				Err:       err,
 			}
-			return nil, &unauthorizedError
+			return &unauthorizedError
 		}
 		dog.OwnerID = user.ID
-		createdDog, err := update(ctx, dog)
-		if err != nil {
+		if err := update(ctx, dog); err != nil {
 			queryError := apperrors.QueryError{
 				Err:       err,
 				Resource:  dog,
 				Operation: apperrors.QueryUpdate,
 			}
-			return nil, &queryError
+			return &queryError
 		}
-		return createdDog, nil
+		return nil
 	}
 }
 

--- a/pkg/services/dogs_test.go
+++ b/pkg/services/dogs_test.go
@@ -171,8 +171,8 @@ func (s ServicesTestSuite) TestNewAuthorizeCreateDog() {
 }
 
 func (s ServicesTestSuite) TestServiceFactory_NewCreateDog() {
-	create := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-		return dog, nil
+	create := func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
+		return &dog.ID, nil
 	}
 
 	authorize := func(user models.User, dog *models.Dog) (bool, error) {
@@ -188,11 +188,10 @@ func (s ServicesTestSuite) TestServiceFactory_NewCreateDog() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
 
-		actualDog, err := createDog(ctx, &dog)
+		dogID, err := createDog(ctx, &dog)
 
 		s.NoError(err)
-		s.NotZero(actualDog.ID)
-		s.Equal(dog.Name, actualDog.Name)
+		s.NotZero(*dogID)
 	})
 
 	s.Run("returns error with no user context", func() {
@@ -249,8 +248,8 @@ func (s ServicesTestSuite) TestServiceFactory_NewCreateDog() {
 	s.Run("returns error when create returns error", func() {
 		createdDog := s.NewDog()
 		fetchErr := errors.New("failed to create")
-		failCreate := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-			return &createdDog, fetchErr
+		failCreate := func(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
+			return nil, fetchErr
 		}
 		createDog := s.ServiceFactory.NewCreateDog(
 			authorize,
@@ -296,8 +295,8 @@ func (s ServicesTestSuite) TestNewAuthorizeUpdateDog() {
 }
 
 func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
-	update := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-		return dog, nil
+	update := func(ctx context.Context, dog *models.Dog) error {
+		return nil
 	}
 
 	fetch := func(ctx context.Context, uuid uuid.UUID) (*models.Dog, error) {
@@ -318,11 +317,9 @@ func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
 
-		actualDog, err := updateDog(ctx, &dog)
+		err := updateDog(ctx, &dog)
 
 		s.NoError(err)
-		s.NotZero(actualDog.ID)
-		s.Equal(dog.Name, actualDog.Name)
 	})
 
 	s.Run("returns error with no user context", func() {
@@ -334,10 +331,9 @@ func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
 		)
 		ctx := context.Background()
 
-		actualDog, err := updateDog(ctx, &dog)
+		err := updateDog(ctx, &dog)
 
 		s.IsType(&apperrors.ContextError{}, err)
-		s.Nil(actualDog)
 	})
 
 	s.Run("returns error when not authorized", func() {
@@ -353,10 +349,9 @@ func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
 
-		actualDog, err := updateDog(ctx, &dog)
+		err := updateDog(ctx, &dog)
 
 		s.IsType(&apperrors.UnauthorizedError{}, err)
-		s.Nil(actualDog)
 	})
 
 	s.Run("returns error when authorize returns error", func() {
@@ -373,10 +368,9 @@ func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
 
-		actualDog, err := updateDog(ctx, &dog)
+		err := updateDog(ctx, &dog)
 
 		s.Equal(authErr, err)
-		s.Nil(actualDog)
 	})
 
 	s.Run("returns error when fetch fail", func() {
@@ -392,17 +386,16 @@ func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
 
-		actualDog, err := updateDog(ctx, &dog)
+		err := updateDog(ctx, &dog)
 
 		s.IsType(&apperrors.QueryError{}, err)
-		s.Nil(actualDog)
 	})
 
 	s.Run("returns error when update returns error", func() {
 		updatedDog := s.NewDog()
 		fetchErr := errors.New("failed to update")
-		failUpdate := func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-			return &updatedDog, fetchErr
+		failUpdate := func(ctx context.Context, dog *models.Dog) error {
+			return fetchErr
 		}
 		updateDog := s.ServiceFactory.NewUpdateDog(
 			authorize,
@@ -412,10 +405,9 @@ func (s ServicesTestSuite) TestServiceFactory_NewUpdateDog() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{})
 
-		actualDog, err := updateDog(ctx, &updatedDog)
+		err := updateDog(ctx, &updatedDog)
 
 		s.IsType(&apperrors.QueryError{}, err)
-		s.Nil(actualDog)
 	})
 }
 

--- a/pkg/sources/postgres/dogs.go
+++ b/pkg/sources/postgres/dogs.go
@@ -31,7 +31,7 @@ func (s *Store) FetchDog(ctx context.Context, id uuid.UUID) (*models.Dog, error)
 }
 
 // CreateDog creates a dog in the DB
-func (s *Store) CreateDog(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
+func (s *Store) CreateDog(ctx context.Context, dog *models.Dog) (*uuid.UUID, error) {
 	dog.ID = uuid.New()
 	const createDogSQL = `
 		INSERT INTO dog (
@@ -53,11 +53,11 @@ func (s *Store) CreateDog(ctx context.Context, dog *models.Dog) (*models.Dog, er
 	if err != nil {
 		return nil, err
 	}
-	return s.FetchDog(ctx, dog.ID)
+	return &dog.ID, nil
 }
 
 // UpdateDog creates a dog in the DB
-func (s *Store) UpdateDog(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
+func (s *Store) UpdateDog(ctx context.Context, dog *models.Dog) error {
 	const updateDogSQL = `
 		UPDATE dog 
 		SET
@@ -69,16 +69,16 @@ func (s *Store) UpdateDog(ctx context.Context, dog *models.Dog) (*models.Dog, er
 
 	result, err := s.db.NamedExec(updateDogSQL, &dog)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if rows == 0 {
-		return nil, &apperrors.ResourceNotFoundError{Resource: dog}
+		return &apperrors.ResourceNotFoundError{Resource: dog}
 	}
-	return s.FetchDog(ctx, dog.ID)
+	return nil
 }
 
 // FetchDogs queries the DB for dogs

--- a/pkg/sources/postgres/dogs_test.go
+++ b/pkg/sources/postgres/dogs_test.go
@@ -20,16 +20,16 @@ func (s StoreTestSuite) TestFetchDog() {
 			BirthDate: s.clock.Now(),
 			OwnerID:   "Owner",
 		}
-		expectedDog, err := s.store.CreateDog(ctx, &insertDog)
+		dogID, err := s.store.CreateDog(ctx, &insertDog)
 		s.NoError(err)
 
-		dog, err := s.store.FetchDog(ctx, expectedDog.ID)
+		dog, err := s.store.FetchDog(ctx, *dogID)
 
 		s.NoError(err)
-		s.Equal(expectedDog.ID, dog.ID)
-		s.Equal(expectedDog.Name, dog.Name)
-		s.Equal(expectedDog.Breed, dog.Breed)
-		s.True(dog.BirthDate.Equal(expectedDog.BirthDate))
+		s.Equal(dog.ID, *dogID)
+		s.Equal(dog.Name, insertDog.Name)
+		s.Equal(dog.Breed, insertDog.Breed)
+		s.True(dog.BirthDate.Equal(insertDog.BirthDate))
 	})
 
 	s.Run("returns error when doesn't exist", func() {
@@ -109,14 +109,21 @@ func (s StoreTestSuite) TestUpdateDog() {
 			BirthDate: s.clock.Now(),
 			OwnerID:   "Owner",
 		}
-		createdDog, err := s.store.CreateDog(ctx, &dog)
+		dogID, err := s.store.CreateDog(ctx, &dog)
 		s.NoError(err)
+
+		createdDog, err := s.store.FetchDog(ctx, *dogID)
+		s.NoError(err)
+
 		createdDog.Name = "Lolita"
-
 		s.NotEqual(dog.Name, createdDog.Name)
-		actualDog, err := s.store.UpdateDog(ctx, createdDog)
 
+		err = s.store.UpdateDog(ctx, createdDog)
 		s.NoError(err)
+
+		actualDog, err := s.store.FetchDog(ctx, *dogID)
+		s.NoError(err)
+
 		s.Equal("Lolita", actualDog.Name)
 	})
 
@@ -129,11 +136,10 @@ func (s StoreTestSuite) TestUpdateDog() {
 			OwnerID:   "Owner",
 		}
 
-		actualDog, err := s.store.UpdateDog(ctx, &dog)
+		err := s.store.UpdateDog(ctx, &dog)
 
 		s.Error(err)
 		s.IsType(&apperrors.ResourceNotFoundError{}, err)
-		s.Nil(actualDog)
 	})
 }
 
@@ -148,13 +154,13 @@ func (s StoreTestSuite) TestFetchDogs() {
 			BirthDate: s.clock.Now(),
 			OwnerID:   "Owner",
 		}
-		expectedDog, err := s.store.CreateDog(ctx, &insertDog)
+		dogID, err := s.store.CreateDog(ctx, &insertDog)
 		s.NoError(err)
 
 		dogs, err := s.store.FetchDogs(ctx)
 
 		s.NoError(err)
 		s.Len(*dogs, 1)
-		s.Equal(expectedDog.ID, (*dogs)[0].ID)
+		s.Equal(*dogID, (*dogs)[0].ID)
 	})
 }


### PR DESCRIPTION
Here is the PR that I "threatened", proposing an approach that approximates Command-Query Responsibility Separation... E.g. making sure the read paths and write paths are separate and distinct from each other.

This pattern also executes a little bit of the Don't Repeat Yourself (DRY) principle as well, if you squint. Pretend that the read/fetch operation somehow gets more complicated, and you update the `FetchDog` appropriately, but you forget to update how the `CreateDog` or `UpdateDog` operations build their response, and then the entity that you get back from `FetchDog` no longer matches what comes back from `CreateDog`/`UpdateDog`... That could lead to some subtle bugs in the code. By forcing everything through the `FetchDog` path, you've effectively DRY'd your code.

Another way that this helps is that it is ready to adjust to high read volume and scale later on down the road. Wanna put REDIS or Memcached caching on the read path? Cool, it's already separated out.

(I generally have felt the same thing should apply at the API layer, i.e. POSTs/PUTs should _not_ return the body of the entity itself, but at most a 301 to the canonical entity location... However Kara convinced me that for purposes of reducing client round-trips to the server, returning those entities might be useful depending on the use-case. I am definitely willing to leave that in the "it depends" bucket.) 

I definitely think read/write separation at the data layer is a MUST. I also built in the separation at the service layer in the PR just to show how it might affect higher layers.