### PR TITLE
Logging tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,21 +321,37 @@ you can send a GET to the health check endpoint:
 
 ### Logging
 
-Logging in this project is intentionally restricted to a single structured log line per request.
-The log line will be either Info or Error Level and will have a variety of key/value pairs associated with it.
-The primary reason for doing things this way is to aid in debugging issues in production by pre-bucketing all info by request. This allows you to use line-oriented tools to quickly determine if there are commonalities between errors. 
+Logging in this project is intentionally restricted to a single structured log
+line per request. The log line will be either Info or Error Level and will have
+a variety of key/value pairs associated with it. The primary reason for doing
+things this way is to aid in debugging issues in production by bucketing
+all info by request. This allows you to use line-oriented tools to quickly
+determine if there are commonalities between errors.
 
-The line logging is performed by the middleware in pkg/server/httpserver/logger.go, in code you interact with it with these methods from appcontext.
+The line logging is performed by the middleware in
+`pkg/server/httpserver/logger.go`, in code you interact with it with these
+methods from `appcontext`.
 
-> //LogRequestField adds a zap.Field to the line logged at the end of the request
-> LogRequestField(ctx context.Context, field zap.Field)
+```go
+// LogRequestField adds a zap.Field to the line logged at the end of the request
+LogRequestField(ctx context.Context, field zap.Field)
+```
 
-You can call this anytime you have a piece of information that you might like associated with this request. e.g.:
-* user_id
-* auth_type
-* number_of_dogs
+You can call this anytime you have a piece of information that you might like
+associated with this request. e.g.:
 
-> // LogRequestError adds a message to the request log line and also sets it to log at the Error level
-> LogRequestError(ctx context.Context, err error)
+* `user_id`
+* `auth_type`
+* `number_of_dogs`
 
-You should call this at most once in a request if you want the request to log at the Error level. The error will be logged with the zap standard "error" key. In general, these should generally correspond with requests that have 5xx status codes. Error log levels may trigger notificactions and require investigation.
+```go
+// LogRequestError adds a message to the request log line and also sets it to
+// log at the Error level
+LogRequestError(ctx context.Context, err error)
+```
+
+You should call this at most once in a request if you want the request to log
+at the Error level. The error will be logged with the zap standard `error` key.
+In general, these should generally correspond with requests that have `5XX`
+status codes. Error log levels may trigger notifications and require
+investigation.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Logging in this project is intentionally restricted to a single structured log l
 The log line will be either Info or Error Level and will have a variety of key/value pairs associated with it.
 The primary reason for doing things this way is to aid in debugging issues in production by pre-bucketing all info by request. This allows you to use line-oriented tools to quickly determine if there are commonalities between errors. 
 
-The line logging is performed by the middleware in pkg/server/httpserver/logger.go, in code you interacti with it with these methods from appcontext. 
+The line logging is performed by the middleware in pkg/server/httpserver/logger.go, in code you interact with it with these methods from appcontext.
 
 > //LogRequestField adds a zap.Field to the line logged at the end of the request
 > LogRequestField(ctx context.Context, field zap.Field)
@@ -336,6 +336,6 @@ You can call this anytime you have a piece of information that you might like as
 * number_of_dogs
 
 > // LogRequestError adds a message to the request log line and also sets it to log at the Error level
-> LogRequestError(ctx context.Context, message string, err error)
+> LogRequestError(ctx context.Context, err error)
 
-You should call this at most once in a request if you want the request to log at the Error level. The message will be logged with an "error_message" key and the error will be logged with the zap standard "error" key. In general, these should generally correspond with requests that have 5xx status codes. Error log levels may trigger notificactions and require investigation. 
+You should call this at most once in a request if you want the request to log at the Error level. The error will be logged with the zap standard "error" key. In general, these should generally correspond with requests that have 5xx status codes. Error log levels may trigger notificactions and require investigation.

--- a/pkg/apis/v1/http/handlers/catch_all_test.go
+++ b/pkg/apis/v1/http/handlers/catch_all_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+
+	"bin/bork/pkg/appcontext"
 )
 
 func (s HandlerTestSuite) TestCatchAllHandler() {
@@ -11,6 +13,7 @@ func (s HandlerTestSuite) TestCatchAllHandler() {
 		rr := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/notAURL", bytes.NewBufferString(""))
 		s.NoError(err)
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 		CatchAllHandler{
 			s.base,
 		}.Handle()(rr, req)

--- a/pkg/apis/v1/http/handlers/dog_test.go
+++ b/pkg/apis/v1/http/handlers/dog_test.go
@@ -45,6 +45,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 		)
 		s.NoError(err)
 		req = mux.SetURLVars(req, map[string]string{"dog_id": dog.ID.String()})
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -70,6 +71,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 		)
 		s.NoError(err)
 		req = mux.SetURLVars(req, map[string]string{"dog_id": ""})
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,
@@ -91,6 +93,7 @@ func (s HandlerTestSuite) TestDogHandler_Handle() {
 		)
 		s.NoError(err)
 		req = mux.SetURLVars(req, map[string]string{"dog_id": "badID"})
+		req = req.WithContext(appcontext.WithEmptyRequestLog(req.Context()))
 
 		DogHandler{
 			s.base,

--- a/pkg/apis/v1/http/handlers/handler_base.go
+++ b/pkg/apis/v1/http/handlers/handler_base.go
@@ -90,7 +90,7 @@ func (b HandlerBase) WriteErrorResponse(ctx context.Context, w http.ResponseWrit
 			)
 		default:
 			code = http.StatusInternalServerError
-			appcontext.LogRequestError(ctx, "DB Query Error", appErr)
+			appcontext.LogRequestError(ctx, fmt.Errorf("DB Query Error: %w", appErr))
 			response = newErrorResponse(
 				code,
 				"Something went wrong",
@@ -99,7 +99,7 @@ func (b HandlerBase) WriteErrorResponse(ctx context.Context, w http.ResponseWrit
 		}
 	case *apperrors.ContextError:
 		code = http.StatusInternalServerError
-		appcontext.LogRequestError(ctx, "Context Error", appErr)
+		appcontext.LogRequestError(ctx, fmt.Errorf("Context Error: %w", appErr))
 		response = newErrorResponse(
 			code,
 			"Something went wrong",
@@ -138,7 +138,7 @@ func (b HandlerBase) WriteErrorResponse(ctx context.Context, w http.ResponseWrit
 		)
 	default:
 		code = http.StatusInternalServerError
-		appcontext.LogRequestError(ctx, "Unexpected Error", appErr)
+		appcontext.LogRequestError(ctx, fmt.Errorf("Unexpected Error: %w", appErr))
 		response = newErrorResponse(
 			code,
 			"Something went wrong",
@@ -149,7 +149,7 @@ func (b HandlerBase) WriteErrorResponse(ctx context.Context, w http.ResponseWrit
 	// get error as response body
 	responseBody, err := json.Marshal(response)
 	if err != nil {
-		appcontext.LogRequestError(ctx, "Failed to marshal error response. Defaulting to generic", err)
+		appcontext.LogRequestError(ctx, fmt.Errorf("Failed to marshal error response. Defaulting to generic: %w", err))
 		http.Error(w, "Something went wrong", http.StatusInternalServerError)
 		return
 	}
@@ -159,7 +159,7 @@ func (b HandlerBase) WriteErrorResponse(ctx context.Context, w http.ResponseWrit
 	w.WriteHeader(code)
 	_, err = w.Write(responseBody)
 	if err != nil {
-		appcontext.LogRequestError(ctx, "Failed to write error response. Defaulting to generic.", err)
+		appcontext.LogRequestError(ctx, fmt.Errorf("Failed to write error response. Defaulting to generic: %w", err))
 		http.Error(w, "Something went wrong", http.StatusInternalServerError)
 		return
 	}

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -12,22 +12,10 @@ import (
 type contextKey int
 
 const (
-	loggerKey contextKey = iota
-	traceKey
+	traceKey contextKey = iota
 	userKey
 	requestLogKey
 )
-
-// WithLogger returns a context with the given logger
-func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
-	return context.WithValue(ctx, loggerKey, logger)
-}
-
-// Logger returns the context's logger
-func Logger(ctx context.Context) (*zap.Logger, bool) {
-	logger, ok := ctx.Value(loggerKey).(*zap.Logger)
-	return logger, ok
-}
 
 // WithTrace returns a context with request trace
 func WithTrace(ctx context.Context) (context.Context, uuid.UUID) {

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -42,9 +42,8 @@ func User(ctx context.Context) (models.User, bool) {
 
 // requestLog keeps track of all the info to be logged in the request log line
 type requestLog struct {
-	fields       []zap.Field
-	errorMessage string
-	error        bool
+	fields []zap.Field
+	err    error
 }
 
 // LogRequestField adds a zap.Field to the line logged at the end of the request
@@ -59,15 +58,14 @@ func LogRequestField(ctx context.Context, field zap.Field) {
 }
 
 // LogRequestError adds a message to the request log line and also sets it to log at the Error level
-func LogRequestError(ctx context.Context, message string, err error) {
+func LogRequestError(ctx context.Context, err error) {
 	requestLog, ok := ctx.Value(requestLogKey).(*requestLog)
 	if !ok {
 		panic("Configuration Error, make sure you call WithEmptyRequestLog before LogRequestField")
 	}
 
+	requestLog.err = err
 	requestLog.fields = append(requestLog.fields, zap.Error(err))
-	requestLog.errorMessage = message
-	requestLog.error = true
 }
 
 // WithEmptyRequestLog returns a context with the request User
@@ -82,12 +80,11 @@ func RequestLogFields(ctx context.Context) ([]zap.Field, bool) {
 	return requestLog.fields, ok
 }
 
-// RequestErrorInfo returns three variables:
-//     did_error bool: true if LogRequestError was called
-//     error_message string: the message logged with the call to LogRequestError
-//     ok bool: wether this data was sucessfully extracted from the context
-func RequestErrorInfo(ctx context.Context) (bool, string, bool) {
+// RequestErrorInfo returns the most recent error, if any
+func RequestErrorInfo(ctx context.Context) error {
 	requestLog, ok := ctx.Value(requestLogKey).(*requestLog)
-
-	return requestLog.error, requestLog.errorMessage, ok
+	if !ok {
+		panic("Configuration Error, make sure you call WithEmptyRequestLog before RequestErrorInfo")
+	}
+	return requestLog.err
 }

--- a/pkg/appcontext/context_test.go
+++ b/pkg/appcontext/context_test.go
@@ -22,27 +22,6 @@ func TestContextTestSuite(t *testing.T) {
 	suite.Run(t, contextTestSuite)
 }
 
-func (s ContextTestSuite) TestWithLogger() {
-	ctx := context.Background()
-	expectedLogger := zap.NewNop()
-
-	ctx = WithLogger(ctx, expectedLogger)
-	logger := ctx.Value(loggerKey).(*zap.Logger)
-
-	s.Equal(expectedLogger, logger)
-}
-
-func (s ContextTestSuite) TestLogger() {
-	ctx := context.Background()
-	expectedLogger := zap.NewNop()
-	ctx = context.WithValue(ctx, loggerKey, expectedLogger)
-
-	logger, ok := Logger(ctx)
-
-	s.True(ok)
-	s.Equal(expectedLogger, logger)
-}
-
 func (s ContextTestSuite) TestWithTrace() {
 	ctx, tID := WithTrace(context.Background())
 	traceID := ctx.Value(traceKey).(uuid.UUID)

--- a/pkg/server/httpserver/auth.go
+++ b/pkg/server/httpserver/auth.go
@@ -7,6 +7,8 @@ import (
 	"bin/bork/pkg/appcontext"
 	"bin/bork/pkg/apperrors"
 	"bin/bork/pkg/models"
+
+	"go.uber.org/zap"
 )
 
 type FakeAuthorizeMiddlewareFactory struct {
@@ -18,8 +20,10 @@ func (m FakeAuthorizeMiddlewareFactory) authorizeMiddleware(next http.Handler) h
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
 			m.base.WriteErrorResponse(r.Context(), w, &apperrors.UnauthorizedError{})
+			return
 		}
 		ctx := appcontext.WithUser(r.Context(), models.User{ID: authHeader})
+		appcontext.LogRequestField(ctx, zap.String("user", authHeader))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/server/httpserver/logger.go
+++ b/pkg/server/httpserver/logger.go
@@ -61,13 +61,10 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 
 		allfields := append(fields, requestFields...)
 
-		didError, errorMessage, ok := appcontext.RequestErrorInfo(ctx)
-		if !ok {
-			logger.Error("Error info not found on this request")
-		}
-
-		if didError {
-			allfields = append(allfields, zap.String("error_message", errorMessage))
+		err := appcontext.RequestErrorInfo(ctx)
+		if err != nil {
+			// the error body was already added to the list
+			// of all fields in LogRequestError
 			logger.Error("Request Complete", allfields...)
 		} else {
 			logger.Info("Request Complete", allfields...)

--- a/pkg/server/httpserver/logger.go
+++ b/pkg/server/httpserver/logger.go
@@ -34,7 +34,6 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 		} else {
 			logger.Error("Failed to get trace ID from context")
 		}
-		ctx = appcontext.WithLogger(ctx, logger)
 		ctx = appcontext.WithEmptyRequestLog(ctx)
 
 		fields := []zap.Field{

--- a/pkg/server/httpserver/logger_test.go
+++ b/pkg/server/httpserver/logger_test.go
@@ -13,46 +13,6 @@ import (
 )
 
 func (s ServerTestSuite) TestLoggerMiddleware() {
-	s.Run("get a new logger with trace ID", func() {
-
-		req := httptest.NewRequest("GET", "/dogs/", nil)
-		rr := httptest.NewRecorder()
-		traceMiddleware := NewTraceMiddleware()
-		prodLogger, err := zap.NewProduction()
-		s.NoError(err)
-		loggerMiddleware := NewLoggerMiddleware(prodLogger)
-
-		// this is the actual test, since the context is cancelled post request
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger, ok := appcontext.Logger(r.Context())
-
-			s.True(ok)
-			s.NotEqual(prodLogger, logger)
-		})
-
-		traceMiddleware(loggerMiddleware(testHandler)).ServeHTTP(rr, req)
-	})
-
-	s.Run("get the same logger with no trace ID", func() {
-
-		req := httptest.NewRequest("GET", "/dogs/", nil)
-		rr := httptest.NewRecorder()
-		// need a new logger, because no-op won't use options
-		prodLogger, err := zap.NewProduction()
-		s.NoError(err)
-		loggerMiddleware := NewLoggerMiddleware(prodLogger)
-
-		// this is the actual test, since the context is cancelled post request
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger, ok := appcontext.Logger(r.Context())
-
-			s.True(ok)
-			s.Equal(prodLogger, logger)
-		})
-
-		loggerMiddleware(testHandler).ServeHTTP(rr, req)
-	})
-
 	s.Run("do a single log field", func() {
 
 		req := httptest.NewRequest("GET", "/dogs/", nil)

--- a/pkg/server/httpserver/logger_test.go
+++ b/pkg/server/httpserver/logger_test.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -66,7 +67,7 @@ func (s ServerTestSuite) TestLoggerMiddleware() {
 			err := errors.New("this test is in error")
 
 			// let's add some log fields
-			appcontext.LogRequestError(r.Context(), "the test errored just like we planned", err)
+			appcontext.LogRequestError(r.Context(), fmt.Errorf("the test errored just like we planned: %w", err))
 
 			w.WriteHeader(500)
 		})
@@ -82,8 +83,10 @@ func (s ServerTestSuite) TestLoggerMiddleware() {
 
 		s.Contains(line.Context, zap.String("host", "example.com"))
 		s.Contains(line.Context, zap.Int("http_status", 500))
-		s.Contains(line.Context, zap.String("error_message", "the test errored just like we planned"))
 
+		err := line.ContextMap()["error"]
+		s.NotNil(err)
+		s.NotContains(err, "the test errored just like we planned")
 	})
 
 }

--- a/pkg/services/dogs.go
+++ b/pkg/services/dogs.go
@@ -90,7 +90,7 @@ func (f ServiceFactory) NewCreateDog(
 		}
 		ok, err := authorize(user, dog)
 		if err != nil {
-			appcontext.LogRequestError(ctx, "failed to authorize createDog", err)
+			appcontext.LogRequestError(ctx, fmt.Errorf("failed to authorize createDog: %w", err))
 			return nil, err
 		}
 		if !ok {
@@ -153,7 +153,7 @@ func (f ServiceFactory) NewUpdateDog(
 		}
 		ok, err = authorize(user, existingDog)
 		if err != nil {
-			appcontext.LogRequestError(ctx, "failed to authorize updateDog", err)
+			appcontext.LogRequestError(ctx, fmt.Errorf("failed to authorize updateDog: %w", err))
 			return nil, err
 		}
 		if !ok {
@@ -203,7 +203,7 @@ func (f ServiceFactory) NewFetchDogs(
 		}
 		ok, err := authorize(user)
 		if err != nil {
-			appcontext.LogRequestError(ctx, "failed to authorize fetchDogs", err)
+			appcontext.LogRequestError(ctx, fmt.Errorf("failed to authorize fetchDogs: %w", err))
 			return nil, err
 		}
 		if !ok {

--- a/pkg/services/dogs.go
+++ b/pkg/services/dogs.go
@@ -79,11 +79,6 @@ func (f ServiceFactory) NewCreateDog(
 	create func(ctx context.Context, dog *models.Dog) (*models.Dog, error),
 ) func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
 	return func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-		logger, ok := appcontext.Logger(ctx)
-		if !ok {
-			logger = f.logger
-			logger.Error("failed to get logger from context in CreateDog service")
-		}
 		user, ok := appcontext.User(ctx)
 		if !ok {
 			contextError := apperrors.ContextError{
@@ -93,9 +88,10 @@ func (f ServiceFactory) NewCreateDog(
 			}
 			return nil, &contextError
 		}
+		appcontext.LogRequestField(ctx, zap.String("user", user.ID))
 		ok, err := authorize(user, dog)
 		if err != nil {
-			logger.Error("failed to authorize createDog", zap.String("user", user.ID))
+			appcontext.LogRequestError(ctx, "failed to authorize createDog", err)
 			return nil, err
 		}
 		if !ok {
@@ -138,11 +134,6 @@ func (f ServiceFactory) NewUpdateDog(
 	fetch func(ctx context.Context, id uuid.UUID) (*models.Dog, error),
 ) func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
 	return func(ctx context.Context, dog *models.Dog) (*models.Dog, error) {
-		logger, ok := appcontext.Logger(ctx)
-		if !ok {
-			logger = f.logger
-			logger.Error("failed to get logger from context in UpdateDog service")
-		}
 		user, ok := appcontext.User(ctx)
 		if !ok {
 			contextError := apperrors.ContextError{
@@ -152,6 +143,7 @@ func (f ServiceFactory) NewUpdateDog(
 			}
 			return nil, &contextError
 		}
+		appcontext.LogRequestField(ctx, zap.String("user", user.ID))
 		existingDog, err := fetch(ctx, dog.ID)
 		if err != nil {
 			queryError := apperrors.QueryError{
@@ -163,7 +155,7 @@ func (f ServiceFactory) NewUpdateDog(
 		}
 		ok, err = authorize(user, existingDog)
 		if err != nil {
-			logger.Error("failed to authorize updateDog", zap.String("user", user.ID))
+			appcontext.LogRequestError(ctx, "failed to authorize updateDog", err)
 			return nil, err
 		}
 		if !ok {
@@ -202,11 +194,6 @@ func (f ServiceFactory) NewFetchDogs(
 	fetch func(ctx context.Context) (*models.Dogs, error),
 ) func(ctx context.Context) (*models.Dogs, error) {
 	return func(ctx context.Context) (*models.Dogs, error) {
-		logger, ok := appcontext.Logger(ctx)
-		if !ok {
-			logger = f.logger
-			logger.Error("failed to get logger from context in FetchDog service")
-		}
 		user, ok := appcontext.User(ctx)
 		if !ok {
 			contextError := apperrors.ContextError{
@@ -216,9 +203,10 @@ func (f ServiceFactory) NewFetchDogs(
 			}
 			return nil, &contextError
 		}
+		appcontext.LogRequestField(ctx, zap.String("user", user.ID))
 		ok, err := authorize(user)
 		if err != nil {
-			logger.Error("failed to authorize fetchDogs", zap.String("user", user.ID))
+			appcontext.LogRequestError(ctx, "failed to authorize fetchDogs", err)
 			return nil, err
 		}
 		if !ok {

--- a/pkg/services/dogs.go
+++ b/pkg/services/dogs.go
@@ -88,7 +88,6 @@ func (f ServiceFactory) NewCreateDog(
 			}
 			return nil, &contextError
 		}
-		appcontext.LogRequestField(ctx, zap.String("user", user.ID))
 		ok, err := authorize(user, dog)
 		if err != nil {
 			appcontext.LogRequestError(ctx, "failed to authorize createDog", err)
@@ -143,7 +142,6 @@ func (f ServiceFactory) NewUpdateDog(
 			}
 			return nil, &contextError
 		}
-		appcontext.LogRequestField(ctx, zap.String("user", user.ID))
 		existingDog, err := fetch(ctx, dog.ID)
 		if err != nil {
 			queryError := apperrors.QueryError{
@@ -203,7 +201,6 @@ func (f ServiceFactory) NewFetchDogs(
 			}
 			return nil, &contextError
 		}
-		appcontext.LogRequestField(ctx, zap.String("user", user.ID))
 		ok, err := authorize(user)
 		if err != nil {
 			appcontext.LogRequestError(ctx, "failed to authorize fetchDogs", err)


### PR DESCRIPTION
I tried to make each of the commits self-contained (they could have each been their own PRs, but didn't wanna spam everyone with small nickel-and-dime changesets):

1. there was still some usage of the "old" logging pattern, this commit replaced those usages with the new logging pattern
2. as Mikena called out in #1, no need to make the services log the `userID`, that can be handled within the middleware layer that puts the `User` object onto the context
3. as proposed in #1, setting the whole request log line to "error" status didn't need a separate `error_message` field, the existence of the error itself is enough to signal setting the level appropriately
4. appease the linters 